### PR TITLE
Support issue tickets displayed in modals

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,20 +1,127 @@
-function main() {
-  // 画面の要素が変わるタイミングで、再度ハンドリング登録
-  const config = {
-    subtree: true,
-    characterData: true,
-  };
+/**
+ * The `AssignChanger` class is responsible for handling automatic assignment
+ * of users in a web application. It observes DOM mutations and listens for
+ * specific keyboard shortcuts to trigger the assignment process.
+ */
+class AssignChanger {
+  /**
+   * Creates an instance of AssignChanger.
+   * @param {Document} document - The document object of the web page.
+   */
+  constructor(document) {
+    this.document = document;
+    /**
+     * Configuration for the MutationObserver to observe changes in the DOM.
+     * @type {Object}
+     * @property {boolean} subtree - Whether to observe changes in the entire subtree.
+     * @property {boolean} characterData - Whether to observe changes in character data.
+     */
+    this.config = {
+      subtree: true,
+      characterData: true,
+    };
+  }
 
-  const callback = function (mutationsList, _) {
+  /**
+   * Starts observing the DOM for mutations using a MutationObserver.
+   */
+  observe() {
+    const observer = new MutationObserver(this.callback);
+    observer.observe(this.document.body, this.config);
+  }
+
+  /**
+   * Callback function for the MutationObserver. Handles mutations in the DOM.
+   * @param {MutationRecord[]} mutationsList - List of mutations observed.
+   * @param {MutationObserver} _ - The MutationObserver instance (unused).
+   */
+  callback = (mutationsList, _) => {
     for (const mutation of mutationsList) {
       if (mutation.type === "characterData") {
-        handleLoadPage();
+        this.handleLoadPage();
       }
     }
   };
 
-  const observer = new MutationObserver(callback);
-  observer.observe(document.body, config);
+  /**
+   * Handles the loading of the page by attaching event listeners to the comment input field.
+   */
+  handleLoadPage() {
+    let comment = this.document.getElementById("leftCommentContent");
+    if (comment) {
+      comment.addEventListener("keydown", this.handleKeydownEvent);
+      this.document.addEventListener("keydown", this.handleKeydownEvent);
+    }
+  }
+
+  /**
+   * Handles the `keydown` event to detect specific keyboard shortcuts.
+   * @param {KeyboardEvent} event - The keyboard event object.
+   */
+  handleKeydownEvent = (event) => {
+    if (
+      (event.metaKey || event.ctrlKey) &&
+      event.shiftKey &&
+      event.code === "KeyA"
+    ) {
+      event.preventDefault();
+      this.handleAutoAssign();
+    }
+  };
+
+  /**
+   * Automatically assigns a user based on the mention in the comment field.
+   * Retrieves the user ID from the mention and assigns them as the responsible user.
+   */
+  handleAutoAssign() {
+    // メンション先のユーザーIDを取得
+    let userIdElement = this.document.querySelector(
+      "#leftCommentContent .at-mention-node"
+    );
+    let userId = userIdElement ? userIdElement.getAttribute("data-id") : null;
+    if (userId === null) {
+      return;
+    }
+
+    // 担当者リストのIDを取得
+    let divElement = this.document.querySelector(
+      "div.change-statuses-properties-item.-assigner div div"
+    );
+    let divId = divElement ? divElement.getAttribute("id") : null;
+
+    // フォーカスを取得
+    let activeElement = this.document.activeElement;
+
+    // 担当者項目をクリックして選択肢を表示
+    if (divId) {
+      let chznContainer = this.document.querySelector(
+        `#${divId} > div.chzn-container button`
+      );
+      if (chznContainer) {
+        chznContainer.click();
+
+        /**
+         * Clicks the assigner in the dropdown list based on the user ID.
+         * @param {string} userId - The ID of the user to assign.
+         * @param {string} divId - The ID of the dropdown container.
+         */
+        const clickAssigner = (userId, divId) => {
+          const listItem = this.document.querySelector(
+            `#${divId}_list-${userId}`
+          );
+          if (listItem) {
+            listItem.click();
+          }
+          activeElement.focus();
+        };
+        setTimeout(() => clickAssigner(userId, divId), 10);
+      }
+    }
+  }
+}
+
+function main() {
+  new AssignChanger(document).observe();
 
   window.addEventListener("load", function () {
     // モーダルで表示される場合、iframeで表示されるため別途observerを設定する
@@ -22,100 +129,10 @@ function main() {
     if (iframe) {
       iframe.addEventListener("load", function () {
         const iframeDocument = this.contentWindow.document;
-
-        const handleKeydownEventForIframe = (event) => {
-          if (
-            (event.metaKey || event.ctrlKey) &&
-            event.shiftKey &&
-            event.code === "KeyA"
-          ) {
-            event.preventDefault();
-            handleAutoAssign(iframeDocument);
-          }
-        };
-
-        const handleLoadPageForIframe = () => {
-          let comment = iframeDocument.getElementById("leftCommentContent");
-          if (comment) {
-            comment.addEventListener("keydown", handleKeydownEventForIframe);
-            iframeDocument.addEventListener(
-              "keydown",
-              handleKeydownEventForIframe
-            );
-          }
-        };
-
-        const callback = function (mutationsList, _) {
-          for (const mutation of mutationsList) {
-            if (mutation.type === "characterData") {
-              handleLoadPageForIframe();
-            }
-          }
-        };
-
-        const observer = new MutationObserver(callback);
-        observer.observe(iframeDocument.body, config);
+        new AssignChanger(iframeDocument).observe();
       });
     }
   });
-}
-
-function handleLoadPage() {
-  let comment = document.getElementById("leftCommentContent");
-  if (comment) {
-    comment.addEventListener("keydown", handleKeydownEvent);
-    document.addEventListener("keydown", handleKeydownEvent);
-  }
-}
-
-function handleKeydownEvent(event) {
-  if (
-    (event.metaKey || event.ctrlKey) &&
-    event.shiftKey &&
-    event.code === "KeyA"
-  ) {
-    event.preventDefault();
-    handleAutoAssign(document);
-  }
-}
-
-function handleAutoAssign(document) {
-  // メンション先のユーザーIDを取得
-  let userIdElement = document.querySelector(
-    "#leftCommentContent .at-mention-node"
-  );
-  let userId = userIdElement ? userIdElement.getAttribute("data-id") : null;
-  if (userId === null) {
-    return;
-  }
-
-  // 担当者リストのIDを取得
-  let divElement = document.querySelector(
-    "div.change-statuses-properties-item.-assigner div div"
-  );
-  let divId = divElement ? divElement.getAttribute("id") : null;
-
-  // フォーカスを取得
-  let activeElement = document.activeElement;
-
-  // 担当者項目をクリックして選択肢を表示
-  if (divId) {
-    let chznContainer = document.querySelector(
-      `#${divId} > div.chzn-container button`
-    );
-    if (chznContainer) {
-      chznContainer.click();
-
-      // メンション先の担当者をクリックして選択
-      setTimeout(function () {
-        let listItem = document.querySelector(`#${divId}_list-${userId}`);
-        if (listItem) {
-          listItem.click();
-        }
-        activeElement.focus();
-      }, 10);
-    }
-  }
 }
 
 main();


### PR DESCRIPTION
# Summary

This pull request introduces functionality to enable auto-assigning users within issue tickets displayed in modals.

On the personal Gantt chart screen, issue tickets are displayed in modals.
see: https://support-ja.backlog.com/hc/ja/articles/360035639974-%E3%83%A1%E3%83%B3%E3%83%90%E3%83%BC%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6#index4

## Problem

The auto-assigning function didn't work in modals.

## Key Changes

1. **Added Auto-Assign Functionality for Modals**
   - On the personal Gantt chart screen, issue tickets are displayed in modals.
   - Since these modals are rendered within `iframe` elements, the existing `MutationObserver` could not detect DOM changes.
   - To address this, a `MutationObserver` is now set up for the `document` inside the `iframe`.

2. **Introduced `AssignChanger` Class**
   - To unify the processing for auto-assign functionality in both the main `document` and `iframe`, the `AssignChanger` class was introduced.
   - This refactoring improves code reusability and readability.

## Other Information
It might be easier to understand if you review the changes commit by commit.